### PR TITLE
[KTLO-0] Refresh after indexing

### DIFF
--- a/easy_elasticsearch/ElasticSearchBM25.py
+++ b/easy_elasticsearch/ElasticSearchBM25.py
@@ -232,6 +232,9 @@ class ElasticSearchBM25(object):
                 for did, documnt in zip(did_chunk, document_chunk)
             ]
             helpers.bulk(self.es, bulk_data)
+        self.es.indices.refresh(
+            index=index_name
+        )  # important!!! otherwise es might return nothing!!!
         logger.info(f"Indexing work done: {ndocuments} documents indexed")
 
     def query(self, query: str, topk, return_scores=False) -> Dict[str, str]:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="easy-elasticsearch",
-    version="0.0.8",
+    version="0.0.9",
     author="Kexin Wang",
     author_email="kexin.wang.2049@gmail.com",
     description="An easy-to-use Elasticsearch BM25 interface",


### PR DESCRIPTION
One must call ` self.es.indices.refresh` after indexing before searching. Otherwise, es might return nothing as the search results. And it seems no way to tell such status.

- `modified:   easy_elasticsearch/ElasticSearchBM25.py`: Added `refresh` after indexing
- `modified:   setup.py`: New version number