### PR TITLE
Fix: Added upper limit on elasticsearch client version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     python_requires=">=3.6",
     install_requires=[
-        "elasticsearch>=7.9.1",  # BeIR requires es==7.9.1
+        "elasticsearch>=7.9.1,<8.0",  # BeIR requires es==7.9.1
         "tqdm",
         "requests",
     ],


### PR DESCRIPTION
Hi, I have noticed, that you use the 7.9.11 version of the docker image, however, by default, `pip install easy-elasticsearch` installs 8.\*.\* version of elasticsearch client, which is [incompatible](https://elasticsearch-py.readthedocs.io/en/v7.17.9/#compatibility) with 7.\*.\* docker images. 

Hence, trying to run the code from the README.md results in this error:
<details>
  <summary>Traceback</summary>

  ```
  ---------------------------------------------------------------------------
  TypeError                                 Traceback (most recent call last)
  Cell In[1], line 8
        1 from easy_elasticsearch import ElasticSearchBM25
        3 pool = {
        4     'id1': 'What is Python? Is it a programming language',
        5     'id2': 'Which Python version is the best?',
        6     'id3': 'Using easy-elasticsearch in Python is really convenient!'
        7 }
  ----> 8 bm25 = ElasticSearchBM25(pool)  # By default, when `host=None` and `mode="docker"`, a ES docker container will be started at localhost.
       10 query = "What is Python?"
       11 rank = bm25.query(query, topk=10)  # topk should be <= 10000
  
  File /easy_elasticsearch/ElasticSearchBM25.py:75, in ElasticSearchBM25.__init__(self, corpus, index_name, reindexing, port_http, port_tcp, host, service_type, es_version, timeout, max_waiting, cache_dir)
       68         logger.info(
       69             "No host running. Now start a new ES service via downloading the executable software"
       70         )
       71         self.pid = self._start_executable_service(
       72             port_http, port_tcp, es_version, max_waiting, cache_dir
       73         )
  ---> 75 es = Elasticsearch(
       76     [
       77         {"host": "localhost", "port": port_http},
       78     ],
       79     timeout=timeout,
       80 )
       81 logger.info(
       82     f"Successfully built connection to ES service at {host}:{port_http}"
       83 )
       84 self.es = es
  
  File /elasticsearch/_sync/client/__init__.py:331, in Elasticsearch.__init__(self, hosts, cloud_id, api_key, basic_auth, bearer_auth, opaque_id, headers, connections_per_node, http_compress, verify_certs, ca_certs, client_cert, client_key, ssl_assert_hostname, ssl_assert_fingerprint, ssl_version, ssl_context, ssl_show_warn, transport_class, request_timeout, node_class, node_pool_class, randomize_nodes_in_pool, node_selector_class, dead_node_backoff_factor, max_dead_node_backoff, serializer, serializers, default_mimetype, max_retries, retry_on_status, retry_on_timeout, sniff_on_start, sniff_before_requests, sniff_on_node_failure, sniff_timeout, min_delay_between_sniffing, sniffed_node_callback, meta_header, timeout, randomize_hosts, host_info_callback, sniffer_timeout, sniff_on_connection_fail, http_auth, maxsize, _transport)
      328         requests_session_auth = http_auth
      329         http_auth = DEFAULT
  --> 331 node_configs = client_node_configs(
      332     hosts,
      333     cloud_id=cloud_id,
      334     requests_session_auth=requests_session_auth,
      335     connections_per_node=connections_per_node,
      336     http_compress=http_compress,
      337     verify_certs=verify_certs,
      338     ca_certs=ca_certs,
      339     client_cert=client_cert,
      340     client_key=client_key,
      341     ssl_assert_hostname=ssl_assert_hostname,
      342     ssl_assert_fingerprint=ssl_assert_fingerprint,
      343     ssl_version=ssl_version,
      344     ssl_context=ssl_context,
      345     ssl_show_warn=ssl_show_warn,
      346 )
      347 transport_kwargs: t.Dict[str, t.Any] = {}
      348 if node_class is not DEFAULT:
  
  File /elasticsearch/_sync/client/utils.py:105, in client_node_configs(hosts, cloud_id, requests_session_auth, **kwargs)
      103 else:
      104     assert hosts is not None
  --> 105     node_configs = hosts_to_node_configs(hosts)
      107 # Remove all values which are 'DEFAULT' to avoid overwriting actual defaults.
      108 node_options = {k: v for k, v in kwargs.items() if v is not DEFAULT}
  
  File /elasticsearch/_sync/client/utils.py:154, in hosts_to_node_configs(hosts)
      151     node_configs.append(url_to_node_config(host))
      153 elif isinstance(host, Mapping):
  --> 154     node_configs.append(host_mapping_to_node_config(host))
      155 else:
      156     raise ValueError(
      157         "'hosts' must be a list of URLs, NodeConfigs, or dictionaries"
      158     )
  
  File /elasticsearch/_sync/client/utils.py:221, in host_mapping_to_node_config(host)
      214     warnings.warn(
      215         "The 'url_prefix' option is deprecated in favor of 'path_prefix'",
      216         category=DeprecationWarning,
      217         stacklevel=warn_stacklevel(),
      218     )
      219     options["path_prefix"] = options.pop("url_prefix")
  --> 221 return NodeConfig(**options)
  
  TypeError: __init__() missing 1 required positional argument: 'scheme'
  ```
</details>

Here is a quick fix that forces pip to install a compatible version of elasticsearch client